### PR TITLE
Changed default values to NC

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -4,11 +4,11 @@
 
         "tx": {
             "help": "TX pin for serial connection to external device (WizFi310)",
-            "value": "D1"
+            "value": "NC"
         },
         "rx": {
             "help": "RX pin for serial connection to external device (WizFi310)",
-            "value": "D0"
+            "value": "NC"
         },
         "debug": {
             "help": "Enable debug logs for (WizFi310)",


### PR DESCRIPTION
We have targets which won't have D0 and D1 defined and will cause compilation error. Therefore changing default values to NC (Not Connected).