### PR TITLE
Fixed a memory leak and inconsistencies between malloc/new/free/delete

### DIFF
--- a/WizFi310/WizFi310.cpp
+++ b/WizFi310/WizFi310.cpp
@@ -305,19 +305,13 @@ void WizFi310::_packet_handler()
         return;
     }
 
-    struct packet *packet = new struct packet;
+    struct packet *packet = new struct packet(id, amount);
     if (!packet) {
         return;
     }
 
-    packet->id = id;
-    packet->len = amount;
-    packet->next = 0;
-    packet->data = (char*)malloc(amount);
-
-    
     if (!(_parser.read((char*)packet->data, amount))) {
-        free(packet);
+        delete(packet);
         setTimeout(_timeout_ms);
         return;
     }
@@ -344,7 +338,7 @@ int32_t WizFi310::recv(int id, void *data, uint32_t amount)
                     *p = (*p)->next;
 
                     uint32_t len = q->len;
-                    free(q);
+                    delete(q);
                     return len;
                 } else { // return only partial packet
                     memcpy(data, q->data, amount);

--- a/WizFi310/WizFi310.h
+++ b/WizFi310/WizFi310.h
@@ -237,6 +237,12 @@ private:
         uint32_t len;
         // data follows
         char *data;
+        packet( int new_id, uint32_t new_len): next(NULL), id(new_id), len(new_len) {
+            this->data = new char[this->len];
+        }
+        ~packet() {
+            delete this->data;
+        }
     } *_packets, **_packets_end;
     void _packet_handler();
     //void _socket_close_handler();


### PR DESCRIPTION
I found a memory leak that was causing crashes after running ~40 minutes, and inconsistencies between the use of new, malloc, free, and delete.