### PR TITLE
add provide-default and implementation for WiFiInteface::get_default_instance

### DIFF
--- a/WizFi310Interface.cpp
+++ b/WizFi310Interface.cpp
@@ -383,3 +383,12 @@ void WizFi310Interface::event()
         }
     }
 }
+
+#if MBED_CONF_WIZFI310_PROVIDE_DEFAULT
+
+WiFiInterface *WiFiInterface::get_default_instance() {
+    static WizFi310Interface wizfi(MBED_CONF_WIZFI310_TX, MBED_CONF_WIZFI310_RX, MBED_CONF_WIZFI310_DEBUG);
+    return &wizfi;
+}
+
+#endif

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -13,6 +13,10 @@
         "debug": {
             "help": "Enable debug logs for (WizFi310)",
             "value": false
+        },
+        "provide-default": {
+            "help": "Provide default WifiInterface. [true/false]",
+            "value": false
         }
     }
 }


### PR DESCRIPTION
Fixes: #9 

Note: this will implementation will require an update when flow control support gets merged.